### PR TITLE
autoformat part 0

### DIFF
--- a/Part0_Introduction/ex0_3_xarray_dataarray.ipynb
+++ b/Part0_Introduction/ex0_3_xarray_dataarray.ipynb
@@ -195,7 +195,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# code here\n"
+    "# code here"
    ]
   },
   {
@@ -348,7 +348,7 @@
     "da0 + da2\n",
     "\n",
     "# what happens?\n",
-    "# "
+    "#"
    ]
   },
   {
@@ -374,7 +374,7 @@
     "da0 + da3\n",
     "\n",
     "# what happens?\n",
-    "# "
+    "#"
    ]
   },
   {
@@ -400,7 +400,7 @@
     "da0 + da4\n",
     "\n",
     "# what happens\n",
-    "# "
+    "#"
    ]
   },
   {
@@ -567,7 +567,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "da = xr.DataArray(data, dims=[\"station\", \"year\"], coords=dict(station=station, year=year))\n",
+    "da = xr.DataArray(\n",
+    "    data, dims=[\"station\", \"year\"], coords=dict(station=station, year=year)\n",
+    ")\n",
     "\n",
     "da"
    ]
@@ -588,7 +590,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# code here\n"
+    "# code here"
    ]
   },
   {
@@ -607,7 +609,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# code here\n"
+    "# code here"
    ]
   },
   {
@@ -626,7 +628,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# code here\n"
+    "# code here"
    ]
   },
   {
@@ -645,7 +647,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# code here\n"
+    "# code here"
    ]
   },
   {
@@ -664,7 +666,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# code here\n"
+    "# code here"
    ]
   },
   {
@@ -683,7 +685,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# code here\n"
+    "# code here"
    ]
   },
   {
@@ -704,7 +706,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# code here\n"
+    "# code here"
    ]
   },
   {
@@ -723,7 +725,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# code here\n"
+    "# code here"
    ]
   },
   {
@@ -743,7 +745,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# code here\n"
+    "# code here"
    ]
   },
   {
@@ -753,7 +755,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#solution\n",
+    "# solution\n",
     "da.plot(hue=\"station\")"
    ]
   }

--- a/Part0_Introduction/ex0_3_xarray_dataarray_solution.ipynb
+++ b/Part0_Introduction/ex0_3_xarray_dataarray_solution.ipynb
@@ -195,7 +195,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# code here\n"
+    "# code here"
    ]
   },
   {
@@ -360,7 +360,7 @@
     "da0 + da2\n",
     "\n",
     "# what happens?\n",
-    "# "
+    "#"
    ]
   },
   {
@@ -403,7 +403,7 @@
     "da0 + da3\n",
     "\n",
     "# what happens?\n",
-    "# "
+    "#"
    ]
   },
   {
@@ -445,7 +445,7 @@
     "da0 + da4\n",
     "\n",
     "# what happens\n",
-    "# "
+    "#"
    ]
   },
   {
@@ -628,7 +628,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "da = xr.DataArray(data, dims=[\"station\", \"year\"], coords=dict(station=station, year=year))\n",
+    "da = xr.DataArray(\n",
+    "    data, dims=[\"station\", \"year\"], coords=dict(station=station, year=year)\n",
+    ")\n",
     "\n",
     "da"
    ]
@@ -649,7 +651,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# code here\n"
+    "# code here"
    ]
   },
   {
@@ -680,7 +682,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# code here\n"
+    "# code here"
    ]
   },
   {
@@ -711,7 +713,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# code here\n"
+    "# code here"
    ]
   },
   {
@@ -742,7 +744,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# code here\n"
+    "# code here"
    ]
   },
   {
@@ -772,7 +774,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# code here\n"
+    "# code here"
    ]
   },
   {
@@ -802,7 +804,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# code here\n"
+    "# code here"
    ]
   },
   {
@@ -835,7 +837,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# code here\n"
+    "# code here"
    ]
   },
   {
@@ -867,7 +869,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# code here\n"
+    "# code here"
    ]
   },
   {
@@ -898,7 +900,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# code here\n"
+    "# code here"
    ]
   },
   {
@@ -908,7 +910,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#solution\n",
+    "# solution\n",
     "da.plot(hue=\"station\")"
    ]
   }

--- a/Part0_Introduction/ex0_4_xarray_dataset.ipynb
+++ b/Part0_Introduction/ex0_4_xarray_dataset.ipynb
@@ -125,7 +125,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# code here\n"
+    "# code here"
    ]
   },
   {
@@ -143,7 +143,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# code here\n"
+    "# code here"
    ]
   },
   {
@@ -183,7 +183,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# code here\n"
+    "# code here"
    ]
   },
   {
@@ -312,7 +312,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# code here\n"
+    "# code here"
    ]
   },
   {
@@ -372,7 +372,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# code here\n"
+    "# code here"
    ]
   },
   {
@@ -410,7 +410,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# code here\n"
+    "# code here"
    ]
   },
   {
@@ -460,7 +460,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# code here\n"
+    "# code here"
    ]
   },
   {

--- a/Part0_Introduction/ex0_4_xarray_dataset_solution.ipynb
+++ b/Part0_Introduction/ex0_4_xarray_dataset_solution.ipynb
@@ -125,7 +125,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# code here\n"
+    "# code here"
    ]
   },
   {
@@ -156,7 +156,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# code here\n"
+    "# code here"
    ]
   },
   {
@@ -208,7 +208,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# code here\n"
+    "# code here"
    ]
   },
   {
@@ -349,7 +349,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# code here\n"
+    "# code here"
    ]
   },
   {
@@ -437,7 +437,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# code here\n"
+    "# code here"
    ]
   },
   {
@@ -488,7 +488,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# code here\n"
+    "# code here"
    ]
   },
   {
@@ -561,7 +561,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# code here\n"
+    "# code here"
    ]
   },
   {


### PR DESCRIPTION
Calls `isort .; black .; flake8 .` for Part 0. This mostly removes some newlines. While this may not be strictly necessary it's still a good idea (as not being aligned with your auto formatter is a constant fight).