### PR TITLE
enironment update: require pooch

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -19,6 +19,7 @@ dependencies:
     - netCDF4
     - numpy
     - pandas
+    - pooch
     - psy-maps
     - scipy
     - seaborn


### PR DESCRIPTION
xarray uses pooch to download example datasets - required for the xarray intro exercises