### PR TITLE
refactor part 4

### DIFF
--- a/Part4_Bonus/ex4_0_defaults_styles_seaborn.ipynb
+++ b/Part4_Bonus/ex4_0_defaults_styles_seaborn.ipynb
@@ -1,21 +1,6 @@
 {
  "cells": [
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# IGNORE THIS CELL WHICH CUSTOMIZES LAYOUT AND STYLING OF THE NOTEBOOK !\n",
-    "%matplotlib inline\n",
-    "%config InlineBackend.figure_format = 'retina'\n",
-    "import warnings\n",
-    "\n",
-    "warnings.filterwarnings(\"ignore\", category=FutureWarning)\n",
-    "warnings.filterwarnings = lambda *a, **kw: None"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -41,7 +26,6 @@
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "\n",
-    "%matplotlib inline\n",
     "dpi = mpl.rcParams[\"figure.dpi\"]"
    ]
   },

--- a/Part4_Bonus/ex4_1_helper_functions.ipynb
+++ b/Part4_Bonus/ex4_1_helper_functions.ipynb
@@ -1,21 +1,6 @@
 {
  "cells": [
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# IGNORE THIS CELL WHICH CUSTOMIZES LAYOUT AND STYLING OF THE NOTEBOOK !\n",
-    "%matplotlib inline\n",
-    "%config InlineBackend.figure_format = 'retina'\n",
-    "import warnings\n",
-    "\n",
-    "warnings.filterwarnings(\"ignore\", category=FutureWarning)\n",
-    "warnings.filterwarnings = lambda *a, **kw: None"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/Part4_Bonus/ex4_2_seaborn.ipynb
+++ b/Part4_Bonus/ex4_2_seaborn.ipynb
@@ -1,21 +1,6 @@
 {
  "cells": [
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# IGNORE THIS CELL WHICH CUSTOMIZES LAYOUT AND STYLING OF THE NOTEBOOK !\n",
-    "%matplotlib inline\n",
-    "%config InlineBackend.figure_format = 'retina'\n",
-    "import warnings\n",
-    "\n",
-    "warnings.filterwarnings(\"ignore\", category=FutureWarning)\n",
-    "warnings.filterwarnings = lambda *a, **kw: None"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -34,12 +19,9 @@
    "outputs": [],
    "source": [
     "import matplotlib.pyplot as plt\n",
-    "\n",
     "import numpy as np\n",
     "import seaborn as sns\n",
-    "import xarray as xr\n",
-    "\n",
-    "%matplotlib inline"
+    "import xarray as xr"
    ]
   },
   {
@@ -83,8 +65,6 @@
     "\n",
     "\n",
     "BAS = load_mch(\"BAS\")\n",
-    "BER = load_mch(\"BER\")\n",
-    "GSB = load_mch(\"GSB\")\n",
     "DAV = load_mch(\"DAV\")"
    ]
   },
@@ -94,7 +74,7 @@
    "source": [
     "## Distributions\n",
     "\n",
-    "While it is easy to create histograms with matplotlib, it's quite difficult to plot a Kernel Density Estimate (kde). With seaborns `distplot` function this is easy:"
+    "While it is binned histograms with matplotlib have a dedicated function in matplotlib, it's difficult to plot a Kernel Density Estimate (kde). Seaborn has specialized functions wich allow to do this directly:"
    ]
   },
   {
@@ -119,22 +99,27 @@
     "ax = axs[0]\n",
     "\n",
     "# Plot a simple histogram with binsize determined automatically\n",
-    "sns.distplot(d, kde=False, color=\"b\", ax=ax, hist_kws=dict(density=True))\n",
+    "sns.histplot(d, kde=False, color=\"b\", ax=ax, stat=\"density\")\n",
     "\n",
     "ax = axs[1]\n",
     "\n",
     "# Plot a kernel density estimate and rug plot\n",
-    "sns.distplot(d, hist=False, rug=True, color=\"r\", ax=ax)\n",
+    "sns.kdeplot(d, color=\"r\", ax=ax)\n",
+    "sns.rugplot(d, color=\"r\", ax=ax)\n",
     "\n",
     "ax = axs[2]\n",
     "\n",
     "# Plot a filled kernel density estimate\n",
-    "sns.distplot(d, hist=False, color=\"g\", kde_kws={\"shade\": True}, ax=ax)\n",
+    "# sns.distplot(d, hist=False, color=\"g\", kde_kws={\"shade\": True}, ax=ax)\n",
+    "sns.kdeplot(d, color=\"g\", fill=True, ax=ax)\n",
+    "\n",
     "\n",
     "ax = axs[3]\n",
     "\n",
     "# Plot a historgram and kernel density estimate\n",
-    "sns.distplot(d, color=\"m\", ax=ax)\n",
+    "sns.kdeplot(d, color=\"m\", ax=ax)\n",
+    "sns.histplot(d, kde=False, color=\"m\", ax=ax, stat=\"density\")\n",
+    "\n",
     "\n",
     "plt.setp(axs, yticks=[])\n",
     "plt.tight_layout()"
@@ -146,7 +131,7 @@
    "source": [
     "### Exercise\n",
     "\n",
-    " * Plot a kde of `BAS.Temperature` and `DAV.Temperature`\n",
+    " * Add a `kdeplot` of `BAS.Temperature` and `DAV.Temperature`\n",
     " * can you add a legend?"
    ]
   },
@@ -156,6 +141,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "f, ax = plt.subplots()\n",
+    "\n",
     "# code here"
    ]
   },
@@ -177,8 +164,10 @@
    },
    "outputs": [],
    "source": [
-    "sns.distplot(BAS.Temperature, hist=False, kde_kws={\"shade\": True, \"label\": \"Basel\"})\n",
-    "sns.distplot(DAV.Temperature, hist=False, kde_kws={\"shade\": True, \"label\": \"Davos\"})\n",
+    "f, ax = plt.subplots()\n",
+    "\n",
+    "sns.kdeplot(BAS.Temperature, fill=True, ax=ax, label=\"Basel\")\n",
+    "sns.kdeplot(DAV.Temperature, fill=True, ax=ax, label=\"Davos\")\n",
     "\n",
     "plt.legend();"
    ]
@@ -355,7 +344,7 @@
    "source": [
     "### Exercise\n",
     "\n",
-    " * create a `factorplot` showing monthly temperature anomalies as a function of the `month` and precipitation category"
+    " * Create a `catplot` showing monthly temperature anomalies as a function of the `month` and precipitation category"
    ]
   },
   {
@@ -366,7 +355,7 @@
    "source": [
     "# code here\n",
     "\n",
-    "# sns.factorplot(...)"
+    "# sns.catplot(...)"
    ]
   },
   {
@@ -397,19 +386,12 @@
     "    palette=\"BrBG\",\n",
     ")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "hide_input": false,
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -423,7 +405,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.2"
+   "version": "3.9.16"
   },
   "toc": {
    "base_numbering": 1,

--- a/Part4_Bonus/ex4_2_seaborn.ipynb
+++ b/Part4_Bonus/ex4_2_seaborn.ipynb
@@ -74,7 +74,7 @@
    "source": [
     "## Distributions\n",
     "\n",
-    "While it is binned histograms with matplotlib have a dedicated function in matplotlib, it's difficult to plot a Kernel Density Estimate (kde). Seaborn has specialized functions wich allow to do this directly:"
+    "While binned histograms have a dedicated function in matplotlib, it's difficult to plot a Kernel Density Estimate (kde). Seaborn has specialized functions which allow to do this directly:"
    ]
   },
   {


### PR DESCRIPTION
This is a small refactor of part 4. The only notable thing is that seaborn deprecates `sns.distplot` and I had to replace it with the current counterparts.