### PR TITLE
fix typos (using codespell)

### DIFF
--- a/Part1_Matplotlib/ex1_1_first_plot.ipynb
+++ b/Part1_Matplotlib/ex1_1_first_plot.ipynb
@@ -231,7 +231,7 @@
    "source": [
     "### Colors and line styles\n",
     "\n",
-    "Here, the colors are choosen automatically - matplotlib loops through a pre-defined list of colors. To manually change the color of the line we can add the `color` keyword.\n",
+    "Here, the colors are chosen automatically - matplotlib loops through a pre-defined list of colors. To manually change the color of the line we can add the `color` keyword.\n",
     "    \n",
     "```python\n",
     "ax.plot(x, y, color=color)\n",
@@ -767,7 +767,7 @@
    "source": [
     "xticks = np.arange(0, 10, np.pi)\n",
     "\n",
-    "# create latex-formatted tick lables\n",
+    "# create latex-formatted tick labels\n",
     "xticklabels = [\"$0$\", \"$\\pi$\", \"$2 \\pi$\", \"$3 \\pi$\"]\n",
     "\n",
     "f, ax = plt.subplots()\n",

--- a/Part1_Matplotlib/ex1_6_annotations_coords.ipynb
+++ b/Part1_Matplotlib/ex1_6_annotations_coords.ipynb
@@ -284,7 +284,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Coordinate sytems & transformations\n",
+    "## Coordinate systems & transformations\n",
     "\n",
     "Until now we have mostly worked with data coordinates. However, you may also wish to write something in the top left corner of the axes irrespective of the data limits. Therefore, matplotlib offers three coordinate systems and the transformations between them:\n",
     "\n",
@@ -435,7 +435,7 @@
     "\n",
     "You could also do `letters = \"abcdef\"` as python happily loops through strings.\n",
     "\n",
-    "If you don't want to write all the letters, you could use `ascii_lowercase` in the `string` module (although remembering this may be more work than just writting the letters down)."
+    "If you don't want to write all the letters, you could use `ascii_lowercase` in the `string` module (although remembering this may be more work than just writing the letters down)."
    ]
   },
   {
@@ -540,7 +540,7 @@
    "source": [
     "## Arrows\n",
     "\n",
-    "Specifiying arrows is not the easiest task in matplotlib... The recommended way to create an arrow is to use `ax.annotate`. The look of the arrow can be controlled with the `arrowprops` keyword. While nearly every aspect can be controlled, it can require very detailed specifications. Matplotlib offers several demos showcasing [annotations](https://matplotlib.org/stable/gallery/userdemo/index.html)."
+    "Specifying arrows is not the easiest task in matplotlib... The recommended way to create an arrow is to use `ax.annotate`. The look of the arrow can be controlled with the `arrowprops` keyword. While nearly every aspect can be controlled, it can require very detailed specifications. Matplotlib offers several demos showcasing [annotations](https://matplotlib.org/stable/gallery/userdemo/index.html)."
    ]
   },
   {

--- a/Part2_Mapplots/ex2_0_intro_scatter.ipynb
+++ b/Part2_Mapplots/ex2_0_intro_scatter.ipynb
@@ -852,7 +852,7 @@
     "\n",
     "### Great circle lines\n",
     "\n",
-    "When plotting a line on a map with `plt.plot(..., transform=ccrs.PlateCarree())` this creates a straight line between the poins and not a great circle line. To show the shorthest path between two points on a sphere (i.e. a great circle line) we need to set `transform=ccrs.Geodetic()`.\n",
+    "When plotting a line on a map with `plt.plot(..., transform=ccrs.PlateCarree())` this creates a straight line between the points and not a great circle line. To show the shorthest path between two points on a sphere (i.e. a great circle line) we need to set `transform=ccrs.Geodetic()`.\n",
     "\n",
     "Let's fly from Zürich (ZRH) to Vancover (YVR):"
    ]

--- a/Part2_Mapplots/ex2_2_psyplot.ipynb
+++ b/Part2_Mapplots/ex2_2_psyplot.ipynb
@@ -254,7 +254,7 @@
    "metadata": {},
    "source": [
     "## Let's do the same on the original grid\n",
-    "We will now get started with [psyplot](https://psyplot.github.io). It has a similiar syntax as other Python packages, e.g. `xr.open_dataset` --> `psy.open_dataset`. For doing map plots, we can use [psyplot.project.plot.mapplot](https://psyplot.github.io/psy-maps/generated/psyplot.project.plot.mapplot.html).\n",
+    "We will now get started with [psyplot](https://psyplot.github.io). It has a similar syntax as other Python packages, e.g. `xr.open_dataset` --> `psy.open_dataset`. For doing map plots, we can use [psyplot.project.plot.mapplot](https://psyplot.github.io/psy-maps/generated/psyplot.project.plot.mapplot.html).\n",
     "\n",
     "First we need to import the psyplot library:"
    ]
@@ -451,7 +451,7 @@
     "\n",
     "Adding borders is still a bit complicated. A nicer way to add them is to use formatoptions, which you can generate yourself. The advantage is that they can be reused across different scripts. Psyplot is designed in a way that it allows users to easily create custom formatoptions. Check [the formatoption approach](https://psyplot.github.io/examples/general/example_extending_psyplot.html#3.-The-formatoption-approach) if you are interested.\n",
     "\n",
-    "MeteoSwiss and C2SM developed [iconarray](https://github.com/C2SM/iconarray), which contains various modules to facilitate working with ICON data. The pacakge also includes some formatoptions like adding borders. Check out their [formatoptions](https://github.com/C2SM/iconarray#formatoptions) and repeat the exercise by using them. The package was developed together with [icon-vis](https://github.com/C2SM/icon-vis), which will be introduced in [Part3_icon-vis](../Part3_icon-vis)."
+    "MeteoSwiss and C2SM developed [iconarray](https://github.com/C2SM/iconarray), which contains various modules to facilitate working with ICON data. The package also includes some formatoptions like adding borders. Check out their [formatoptions](https://github.com/C2SM/iconarray#formatoptions) and repeat the exercise by using them. The package was developed together with [icon-vis](https://github.com/C2SM/icon-vis), which will be introduced in [Part3_icon-vis](../Part3_icon-vis)."
    ]
   },
   {

--- a/Part4_Bonus/ex4_1_helper_functions.ipynb
+++ b/Part4_Bonus/ex4_1_helper_functions.ipynb
@@ -582,7 +582,7 @@
    "source": [
     "### Defining the function in an external file\n",
     "\n",
-    "When you want to use your helper function in multiple notebooks, you need to add it to a seperate \\*.py file. Have a look at the [utils.py](utils.py) file in the current folder. It contains the `add_line` function.\n"
+    "When you want to use your helper function in multiple notebooks, you need to add it to a separate \\*.py file. Have a look at the [utils.py](utils.py) file in the current folder. It contains the `add_line` function.\n"
    ]
   },
   {
@@ -1277,7 +1277,7 @@
     "\n",
     "> $\\alpha = \\frac{\\exp(\\mathrm{co2} * \\gamma)}{\\exp(\\max(\\mathrm{co2}) * \\gamma)}$\n",
     "\n",
-    "$\\gamma$ is determind by testing various values."
+    "$\\gamma$ is determined by testing various values."
    ]
   },
   {

--- a/Part4_Bonus/ex4_2_seaborn.ipynb
+++ b/Part4_Bonus/ex4_2_seaborn.ipynb
@@ -116,7 +116,7 @@
     "\n",
     "ax = axs[3]\n",
     "\n",
-    "# Plot a historgram and kernel density estimate\n",
+    "# Plot a histogram and kernel density estimate\n",
     "sns.kdeplot(d, color=\"m\", ax=ax)\n",
     "sns.histplot(d, kde=False, color=\"m\", ax=ax, stat=\"density\")\n",
     "\n",

--- a/Part5_User-contributions/ex5_3_distributions_W_Ball.ipynb
+++ b/Part5_User-contributions/ex5_3_distributions_W_Ball.ipynb
@@ -122,7 +122,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## All distrubutions\n",
+    "## All distributions\n",
     "\n",
     "Let's plot all distributions next to each other\n",
     "\n",
@@ -522,7 +522,7 @@
     "* write a function to format the axes\n",
     "  * currently this function will only contain the loop and `axvline`, we will add more later\n",
     "  * It should have the following signature: `format_ax(ax, x_positions)`\n",
-    "  * don't forget to delete the `axvline` commant in `plot_distr` \n",
+    "  * don't forget to delete the `axvline` command in `plot_distr` \n",
     "  \n",
     "* you can remove the `pass` command once you're done"
    ]

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The lectures consist of IPython Notebooks.
 
 Python beginners who should have programming experience in other
 languages. Most examples and exercises are drawn from the field
-of Climate Reseach.
+of Climate Research.
 
 ## Duration
 

--- a/data/prepare_CMIP5_map.ipynb
+++ b/data/prepare_CMIP5_map.ipynb
@@ -135,7 +135,7 @@
     "\n",
     "for fN in fNs:\n",
     "\n",
-    "    # open datset\n",
+    "    # open dataset\n",
     "    ds = xr.open_dataset(fN)\n",
     "    ds.load()\n",
     "\n",

--- a/data/prepare_HadEX2_GSL.ipynb
+++ b/data/prepare_HadEX2_GSL.ipynb
@@ -101,7 +101,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Create a function that calculates the regression slope for one pixes. Then apply the function to each lon/ lat pixel. After a [example](https://gist.github.com/rabernat/bc4c6990eb20942246ce967e6c9c3dbe) by [Ryan Abernathey](https://github.com/rabernat)."
+    "Create a function that calculates the regression slope for one pixels. Then apply the function to each lon/ lat pixel. After a [example](https://gist.github.com/rabernat/bc4c6990eb20942246ce967e6c9c3dbe) by [Ryan Abernathey](https://github.com/rabernat)."
    ]
   },
   {

--- a/data/prepare_data_MCH.ipynb
+++ b/data/prepare_data_MCH.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Montly data of precip and temperature from MeteoSwiss\n",
+    "# Monthly data of precip and temperature from MeteoSwiss\n",
     "\n",
     "obained from http://www.meteoswiss.admin.ch/home/climate/past/homogenous-monthly-data.html?region=Table"
    ]


### PR DESCRIPTION
I forgot again about the codespell package that we can use to find some more typos...

```bash
codespell --skip=".git,devel,./docs/build,*.pdf,.backup" --ignore-words-list "" . -i 3
```