### PR TITLE
mpu.colobar: draw() no longer required

### DIFF
--- a/Part2_Mapplots/ex2_3_colorbars.ipynb
+++ b/Part2_Mapplots/ex2_3_colorbars.ipynb
@@ -73,44 +73,9 @@
     "plt.colorbar(h, ax=ax)\n",
     "```\n",
     "    \n",
-    "### Exercise\n",
+    "### Example\n",
     "\n",
-    "We plot the relative change in precipitation between a historical and future time period, calculated from CMIP5 data.\n",
-    "\n",
-    " * Add a colorbar\n",
-    " * Use the `label` keyword argument to indicate that we show a `'Relative change (%)'`"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "f, ax = plt.subplots(1, 1, subplot_kw=dict(projection=ccrs.PlateCarree()))\n",
-    "\n",
-    "h = ax.pcolormesh(\n",
-    "    pr.lon,\n",
-    "    pr.lat,\n",
-    "    pr.pr_rel,\n",
-    "    transform=ccrs.PlateCarree(),\n",
-    "    cmap=\"BrBG\",\n",
-    "    vmin=-50,\n",
-    "    vmax=50,\n",
-    ")\n",
-    "\n",
-    "ax.set_title(\"Precipitation\")\n",
-    "ax.coastlines()\n",
-    "\n",
-    "# ==========================\n",
-    "# add colorbar"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Solution"
+    "We plot the relative change in precipitation between a historical and future time period, calculated from CMIP5 data - including a colorbar:"
    ]
   },
   {
@@ -118,6 +83,7 @@
    "execution_count": null,
    "metadata": {
     "hide_input": true,
+    "metadata": {},
     "tags": [
      "solution"
     ]
@@ -141,7 +107,7 @@
     "\n",
     "# =======\n",
     "# add colorbar\n",
-    "cbar = plt.colorbar(h, ax=ax, label=\"Relative change (%)\")"
+    "plt.colorbar(h, ax=ax, label=\"Relative change (%)\")"
    ]
   },
   {
@@ -179,7 +145,7 @@
    "source": [
     "#### Why is this a problem for map plots but not for others?\n",
     "\n",
-    "We have seen examples where the colorbar just worked fine with axes. The issue is that the aspect ratio of a map plot has to be equal, else the map would be distorted. Matplotlib then shrinks the axes, but does not shrink the area of the figure. The colorbar is correct when we set the aspect to `\"auto\"`, but then of course the map is distorted..."
+    "We have seen examples where the colorbar just worked fine. The issue is that the aspect ratio of a map plot has to be equal, otherwise the map would be distorted. To achieve this, matplotlib shrinks the axes, but does not shrink the figure itself. The colorbar is correct if we set the aspect to `\"auto\"`, but then of course the map is distorted..."
    ]
   },
   {
@@ -210,7 +176,7 @@
    "source": [
     "# The solution\n",
     "\n",
-    "There is a function in mplotutils that creates colorbars of the correct size - `mpu.colorbar`.\n",
+    "There is a function in mplotutils that creates colorbars of the correct size: `mpu.colorbar(...)`.\n",
     "\n",
     "The solution is inspired by this [stackoverflow answer](https://stackoverflow.com/a/30077745). The trick is to read out the coordinates of the cartopy axes and adjust the position of the colorbar accordingly. Because the position of the cartopy axes can change, we have to redo this every time the plot gets drawn."
    ]
@@ -233,12 +199,10 @@
     "h = ax.pcolormesh(lon, lat, data, transform=ccrs.PlateCarree())\n",
     "\n",
     "# =======\n",
-    "# add mpu.colorbar\n",
+    "# NOTE: mpu.colorbar instead of plt.colorbar\n",
     "cbar = mpu.colorbar(h, ax, extend=\"both\", orientation=\"horizontal\", aspect=15, pad=0.05)\n",
     "\n",
-    "cbar.set_ticks(np.arange(-1, 1.1, 0.5))\n",
-    "\n",
-    "f.canvas.draw()"
+    "cbar.set_ticks(np.arange(-1, 1.1, 0.5))"
    ]
   },
   {
@@ -266,8 +230,7 @@
     "\n",
     "Let's go back to the relative precipitation change\n",
     "\n",
-    " * Add a horizontal colorbar\n",
-    " * Add the units (`\"(mm)\"`) below the colorbar (use `cbar.set_label`)\n",
+    " * Replace the `plt` colorbar with the `mpu` one.\n",
     " \n",
     " > Note: we use xarray to plot the data - therefore we need to set `add_colorbar=False`"
    ]
@@ -287,13 +250,7 @@
     "\n",
     "# =======\n",
     "# use mpu.colorbar instead\n",
-    "plt.colorbar(h)\n",
-    "\n",
-    "# add the units\n",
-    "\n",
-    "\n",
-    "# tell mpl to draw\n",
-    "f.canvas.draw()"
+    "cbar = plt.colorbar(h, label=\"(mm)\")"
    ]
   },
   {
@@ -308,6 +265,7 @@
    "execution_count": null,
    "metadata": {
     "hide_input": true,
+    "metadata": {},
     "tags": [
      "solution"
     ]
@@ -322,14 +280,8 @@
     ")\n",
     "\n",
     "# =======\n",
-    "# use mpu.colorbar\n",
-    "cbar = mpu.colorbar(h, ax)\n",
-    "\n",
-    "# add the units\n",
-    "cbar.set_label(\"(mm)\")\n",
-    "\n",
-    "# tell mpl to draw\n",
-    "plt.draw()"
+    "# use mpu.colorbar instead\n",
+    "cbar = mpu.colorbar(h, ax, label=\"(mm)\")"
    ]
   },
   {
@@ -416,6 +368,7 @@
    "execution_count": null,
    "metadata": {
     "hide_input": true,
+    "metadata": {},
     "tags": [
      "solution"
     ]
@@ -468,13 +421,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> If the colorbar is not at the correct position in the PDF, you need to add a `f.canvas.draw()` command just before `plt.savefig(...)`."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Some more stuff you can do\n",
     "\n",
     "* Span multiple axes\n",
@@ -520,11 +466,7 @@
     "\n",
     "# ====\n",
     "# colorbar for three axes\n",
-    "cbar = mpu.colorbar(h3, axs[-1], axs[3], size=0.2, pad=0.1, orientation=\"horizontal\")\n",
-    "\n",
-    "# ====\n",
-    "\n",
-    "f.canvas.draw()"
+    "cbar = mpu.colorbar(h3, axs[-1], axs[3], size=0.2, pad=0.1, orientation=\"horizontal\")"
    ]
   },
   {
@@ -563,9 +505,7 @@
     "\n",
     "ax = axs[3]\n",
     "mpu.colorbar(h, ax, orientation=\"horizontal\", shrink=None, shift=0.2)\n",
-    "ax.text(0.5, 0.5, \"shrink=None (default)\\nshift=0.2\", ha=\"center\", va=\"center\")\n",
-    "\n",
-    "plt.draw()"
+    "ax.text(0.5, 0.5, \"shrink=None (default)\\nshift=0.2\", ha=\"center\", va=\"center\")"
    ]
   },
   {
@@ -639,9 +579,7 @@
     "\n",
     "\n",
     "# second colorbar\n",
-    "\n",
-    "\n",
-    "f.canvas.draw()"
+    "\n"
    ]
   },
   {
@@ -658,6 +596,7 @@
    "execution_count": null,
    "metadata": {
     "hide_input": true,
+    "metadata": {},
     "tags": [
      "solution"
     ]
@@ -715,9 +654,7 @@
     "\n",
     "# second colorbar\n",
     "cbar = mpu.colorbar(h2, axs[2], shift=0.15, size=0.05, extendfrac=0.1, extend=\"both\")\n",
-    "cbar.ax.set_xlabel(\"(%)\", labelpad=10, ha=\"left\")\n",
-    "\n",
-    "f.canvas.draw()"
+    "cbar.ax.set_xlabel(\"(%)\", labelpad=10, ha=\"left\")"
    ]
   },
   {
@@ -817,6 +754,7 @@
    "execution_count": null,
    "metadata": {
     "hide_input": true,
+    "metadata": {},
     "tags": [
      "solution"
     ]
@@ -873,7 +811,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.6"
+   "version": "3.11.8"
   }
  },
  "nbformat": 4,

--- a/Part2_Mapplots/ex2_4_stippling.ipynb
+++ b/Part2_Mapplots/ex2_4_stippling.ipynb
@@ -71,9 +71,7 @@
     "ax.set_global()\n",
     "\n",
     "# add colorbar\n",
-    "mpu.colorbar(h, ax, aspect=15, pad=0.025)\n",
-    "\n",
-    "f.canvas.draw()"
+    "mpu.colorbar(h, ax, aspect=15, pad=0.025)"
    ]
   },
   {
@@ -174,9 +172,7 @@
     ")\n",
     "\n",
     "# add colorbar\n",
-    "mpu.colorbar(h, ax, spacing=\"proportional\", aspect=15)\n",
-    "\n",
-    "plt.draw()"
+    "mpu.colorbar(h, ax, spacing=\"proportional\", aspect=15)"
    ]
   },
   {
@@ -191,6 +187,7 @@
    "execution_count": null,
    "metadata": {
     "hide_input": true,
+    "metadata": {},
     "tags": [
      "solution"
     ]
@@ -223,9 +220,7 @@
     ")\n",
     "\n",
     "# add colorbar\n",
-    "mpu.colorbar(h, ax, spacing=\"proportional\", aspect=15)\n",
-    "\n",
-    "plt.draw()"
+    "mpu.colorbar(h, ax, spacing=\"proportional\", aspect=15)"
    ]
   },
   {
@@ -280,9 +275,7 @@
     "\n",
     "\n",
     "# add colorbar\n",
-    "mpu.colorbar(h, ax, spacing=\"proportional\", aspect=15)\n",
-    "\n",
-    "plt.draw()"
+    "mpu.colorbar(h, ax, spacing=\"proportional\", aspect=15)"
    ]
   },
   {
@@ -461,7 +454,6 @@
     "\n",
     "# ax.set_title('T2M: Ranked probability skill score, JJA')\n",
     "\n",
-    "f.canvas.draw()\n",
     "# plt.savefig('ex_stippling_RPSS.png', dpi=300)"
    ]
   },
@@ -500,9 +492,7 @@
     "# h = ax.contourf(...)\n",
     "\n",
     "# add colorbar\n",
-    "mpu.colorbar(h, ax, spacing=\"proportional\")\n",
-    "\n",
-    "plt.draw()"
+    "mpu.colorbar(h, ax, spacing=\"proportional\")"
    ]
   },
   {
@@ -517,6 +507,7 @@
    "execution_count": null,
    "metadata": {
     "hide_input": true,
+    "metadata": {},
     "tags": [
      "solution"
     ]
@@ -537,9 +528,7 @@
     "h = ax.contourf(LON, lat, PVAL, transform=ccrs.PlateCarree())\n",
     "\n",
     "# add colorbar\n",
-    "mpu.colorbar(h, ax, spacing=\"proportional\")\n",
-    "\n",
-    "plt.draw()"
+    "mpu.colorbar(h, ax, spacing=\"proportional\")"
    ]
   },
   {
@@ -577,9 +566,7 @@
     "h = ax.contourf(LON, lat, PVAL, transform=ccrs.PlateCarree())\n",
     "\n",
     "# add colorbar\n",
-    "mpu.colorbar(h, ax, spacing=\"proportional\")\n",
-    "\n",
-    "plt.draw()"
+    "mpu.colorbar(h, ax, spacing=\"proportional\")"
    ]
   },
   {
@@ -622,9 +609,7 @@
     "ax.set_global()\n",
     "\n",
     "# add colorbar\n",
-    "mpu.colorbar(h, ax, spacing=\"proportional\")\n",
-    "\n",
-    "plt.draw()"
+    "mpu.colorbar(h, ax, spacing=\"proportional\")"
    ]
   },
   {
@@ -669,9 +654,7 @@
     ")\n",
     "\n",
     "# add colorbar\n",
-    "mpu.colorbar(h, ax, spacing=\"proportional\")\n",
-    "\n",
-    "plt.draw()"
+    "mpu.colorbar(h, ax, spacing=\"proportional\")"
    ]
   },
   {
@@ -727,9 +710,7 @@
     ")\n",
     "\n",
     "# add colorbar\n",
-    "mpu.colorbar(h, ax, spacing=\"proportional\")\n",
-    "\n",
-    "plt.draw()"
+    "mpu.colorbar(h, ax, spacing=\"proportional\")"
    ]
   },
   {
@@ -783,9 +764,7 @@
     "ax.plot(LON, LAT, \".\", color=\"0.1\", transform=ccrs.PlateCarree(), ms=1)\n",
     "\n",
     "# add colorbar\n",
-    "mpu.colorbar(h, ax, spacing=\"proportional\")\n",
-    "\n",
-    "f.canvas.draw()"
+    "mpu.colorbar(h, ax, spacing=\"proportional\")"
    ]
   }
  ],
@@ -806,7 +785,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.14"
+   "version": "3.11.8"
   },
   "toc": {
    "base_numbering": 1,

--- a/Part5_User-contributions/ex5_2_multiple_regional_maps_M_Hauser.ipynb
+++ b/Part5_User-contributions/ex5_2_multiple_regional_maps_M_Hauser.ipynb
@@ -683,8 +683,6 @@
     "f.subplots_adjust(left=0.025, right=0.975, bottom=0.2)\n",
     "mpu.set_map_layout(ax, 17)\n",
     "\n",
-    "plt.draw()\n",
-    "\n",
     "# plt.savefig('ex5_multiple_regional_maps_M_Hauser.png', dpi=300)"
    ]
   }


### PR DESCRIPTION
- [x] closes #118

Remove mentions of `f.canvas.draw()` and `plt.draw()` which is no longer necessary with mplotutils v0.4.0, which is now also installed in iacpy3_2024.


@AnnikaLau just FYI